### PR TITLE
docs: add current rules documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ For monorepos or modular projects, add `.cursor/rules` folders to subdirectories
 - [cursor directory](https://cursor.directory/)
 - [awesome cursor rules](https://github.com/PatrickJS/awesome-cursorrules?tab=readme-ov-file#utilities)
 - [johnlindquist rules](https://github.com/johnlindquist/cursor-demos/blob/main/.cursor/rules/prompt-improve.mdc)
+
+## 📂 Current Rules
+
+This repository contains organized cursor rules in `.cursor/rules/`:
+
+- **Git Rules** (`git/`) - Conventional commits and PR guidelines
+- **AI Behavior** - Prompt improvement guidelines


### PR DESCRIPTION
## 📝 Summary

Add documentation section to README that describes the current organized rule structure.

## 📂 Changes

- [x] Documentation
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Rule update (`.cursor/rules`)
- [ ] Other

## ✅ What's Included

- Added "Current Rules" section to README.md
- Documented the organized `.cursor/rules` directory structure
- Listed available git workflow and AI behavior rules

## 🧪 How to Test

```bash
cat README.md
ls -la .cursor/rules/
```
